### PR TITLE
Small adjustments to the Scope deep links

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
 	"version": "0.0.1",
 	"publisher": "rasquill",
 	"repository": {
-        "type": "git",
-        "url": "https://github.com/squillace/kube-scope-weave"
-    },
+		"type": "git",
+		"url": "https://github.com/squillace/kube-scope-weave"
+	},
 	"engines": {
 		"vscode": "^1.32.0"
 	},


### PR DESCRIPTION
#### Changes

* Cluster now links to the clean (non-cached) Scope UI state
* Removed all the extra pre-filtering (@squillace, I wasn't sure if you actually wanted to keep any from [here](https://github.com/squillace/kube-scope-weave/compare/master...fbarl:scope-links-small-fixes?expand=1#diff-45327f86d4438556066de133327f4ca2L220))
* Fixed the namespace selection in deep links from namespaces
* _Pod_ and _Service_ views can be quite big, so I set the search query to the active node name there to highlight that node in deep links (see the screenshot below) - the proper solution of having that node selected requires https://github.com/weaveworks/scope/issues/3122 to be implemented first

![image](https://user-images.githubusercontent.com/1216874/57531787-8cdb7200-733a-11e9-9b5f-2ffc2294d2f2.png)
